### PR TITLE
Set the private property in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "name": "unavatar",
   "description": "Get user avatar across social services.",
+  "private": true,
   "homepage": "https://unavatar.now.sh",
   "version": "0.0.0",
   "main": "src/index.js",


### PR DESCRIPTION
Since this project is a service, I guess it's not planned to publish it to the NPM registry. To avoid `npm` command line to publish it, I added the [private property](https://docs.npmjs.com/files/package.json#private) to the `package.json` file