### PR TITLE
Add YouTube Support

### DIFF
--- a/now.json
+++ b/now.json
@@ -1,5 +1,8 @@
 {
   "name": "unavatar",
   "public": true,
-  "alias": "unavatar.now.sh"
+  "alias": "unavatar.now.sh",
+  "env": {
+    "YOUTUBE_API_KEY": "@youtube_api_key"
+  }
 }

--- a/package.json
+++ b/package.json
@@ -28,10 +28,12 @@
   },
   "keywords": [],
   "dependencies": {
-    "aigle": "~1.12.0-alpha.6",
+    "aigle": "~1.12.0-alpha.10",
+    "beauty-error": "~1.0.1",
     "cheerio": "~1.0.0-rc.2",
     "compression": "~1.7.2",
     "cors": "~2.8.4",
+    "debug": "~4.1.0",
     "express": "~4.16.3",
     "got": "~9.3.0",
     "helmet": "~3.14.0",
@@ -43,9 +45,8 @@
     "lodash": "~4.17.10",
     "memoize-one": "~4.0.2",
     "morgan": "~1.9.0",
+    "p-any": "~1.1.0",
     "p-timeout": "~2.0.1",
-    "request": "~2.88.0",
-    "request-promise": "~4.2.2",
     "url-regex": "~4.1.1"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -9,6 +9,16 @@
     "name": "Kiko Beats",
     "url": "https://kikobeats.com"
   },
+  "contributors": [
+    {
+      "name": "Travis CI",
+      "email": "travis@travis-ci.org"
+    },
+    {
+      "name": "Angel M De Miguel",
+      "email": "angel@bitnami.com"
+    }
+  ],
   "repository": {
     "type": "git",
     "url": "git+https://github.com/Kikobeats/unavatar.git"
@@ -34,6 +44,8 @@
     "memoize-one": "~4.0.2",
     "morgan": "~1.9.0",
     "p-timeout": "~2.0.1",
+    "request": "~2.88.0",
+    "request-promise": "~4.2.2",
     "url-regex": "~4.1.1"
   },
   "devDependencies": {
@@ -119,9 +131,5 @@
     "scripts": {
       "prechangelog": "git-authors-cli"
     }
-  },
-  "contributors": [
-    "Travis CI <travis@travis-ci.org>",
-    "Angel M De Miguel <angel@bitnami.com>"
-  ]
+  }
 }

--- a/src/avatar-url.js
+++ b/src/avatar-url.js
@@ -1,6 +1,8 @@
 'use strict'
 
 const isAbsoluteUrl = require('is-absolute-url')
+const beautyError = require('beauty-error')
+const debug = require('debug')('unavatar')
 const memoizeOne = require('memoize-one')
 const isUrlHttp = require('is-url-http')
 const { get, isNil } = require('lodash')
@@ -62,7 +64,7 @@ module.exports = (fn = getAvatarUrl) => async (req, res) => {
   try {
     url = await pTimeout(fn(username, fallbackUrl), avatarTimeout)
   } catch (err) {
-    console.log('err', err)
+    debug(beautyError(err))
     url = fallbackUrl
   }
 

--- a/src/constant.js
+++ b/src/constant.js
@@ -10,5 +10,6 @@ module.exports = {
   cacheTTL: process.env.CACHE_TTL || TWENTY_FOUR_HOURS,
   logLevel: process.env.LOGLEVEL || isProduction ? 'combined' : 'dev',
   avatarSize: process.env.AVATAR_SIZE || 400,
-  avatarTimeout: process.env.AVATAR_TIMEOUT || 3000
+  avatarTimeout: process.env.AVATAR_TIMEOUT || 3000,
+  youtubeApiKey: process.env.YOUTUBE_API_KEY
 }

--- a/src/providers/index.js
+++ b/src/providers/index.js
@@ -8,6 +8,7 @@ const providers = {
   clearbit: require('./clearbit'),
   github: require('./github'),
   facebook: require('./facebook'),
+  youtube: require('./youtube'),
   // gravatar returns a default avatar, so use it as fallback
   gravatar: require('./gravatar')
 }

--- a/src/providers/youtube.js
+++ b/src/providers/youtube.js
@@ -18,7 +18,7 @@ async function getChannelInfo (channelUrl) {
     url: 'https://content.googleapis.com/youtube/v3/channels',
     qs: {
       part: 'id,snippet',
-      key: 'AIzaSyAnEy2O9Iwf1qn7-U8AxoajQ2nw0OlDxyg'
+      key: constant.youtubeApiKey
     },
     headers: { 'cache-control': 'no-cache' },
     json: true

--- a/src/providers/youtube.js
+++ b/src/providers/youtube.js
@@ -1,0 +1,50 @@
+'use strict'
+
+const { chain } = require('lodash')
+const request = require('request-promise')
+const url = require('url')
+const constant = require('../constant')
+
+async function getChannelInfo (channelUrl) {
+  const parts = url.parse(channelUrl).pathname.split('/')
+
+  const slug = chain(parts)
+    .filter(p => p !== '')
+    .last()
+    .value()
+
+  const options = {
+    method: 'GET',
+    url: 'https://content.googleapis.com/youtube/v3/channels',
+    qs: {
+      part: 'id,snippet',
+      key: 'AIzaSyAnEy2O9Iwf1qn7-U8AxoajQ2nw0OlDxyg'
+    },
+    headers: { 'cache-control': 'no-cache' },
+    json: true
+  }
+  if (channelUrl.includes('/user')) {
+    options.qs.forUsername = slug
+  } else {
+    options.qs.id = slug
+  }
+
+  const body = await request(options)
+  if (body && body.pageInfo && body.pageInfo.totalResults > 0) {
+    return body.items[0]
+  }
+}
+
+module.exports = async username => {
+  const youtubeChannelInfo = await getChannelInfo(username)
+  return (
+    youtubeChannelInfo.snippet &&
+    youtubeChannelInfo.snippet.thumbnails.default.url
+  )
+}
+
+module.exports.supported = {
+  email: false,
+  username: true,
+  domain: true
+}

--- a/static/index.html
+++ b/static/index.html
@@ -81,6 +81,9 @@
     <h3>Twitter</h3>
     <p><code>&lt;img src="https://unavatar.now.sh/twitter/:username" /&gt;</code></p>
     <p>i.e <a target="_blank" href="https://unavatar.now.sh/twitter/kikobeats">https://unavatar.now.sh/twitter/kikobeats</a></p>
+    <h3>YouTube</h3>
+    <p><code>&lt;img src="https://unavatar.now.sh/youtube/:username" /&gt;</code></p>
+    <p>i.e <a target="_blank" href="https://unavatar.now.sh/youtube/caseyneistat">https://unavatar.now.sh/youtube/caseyneistat</a></p>
     <h3>Other domain</h3>
     <p><code>&lt;img src="https://unavatar.now.sh/domain/:domain" /&gt;</code></p>
     <p>i.e <a target="_blank" href="https://unavatar.now.sh/domain/reddit.com">https://unavatar.now.sh/domain/reddit.com</a></p>


### PR DESCRIPTION
Closes #13 

Based on https://github.com/Kikobeats/unavatar/pull/21

Changes compared with the original PR:

- Used `got` instead of `request`.
- Resolve YouTube usernames, no need to be prefixed with `/user`.


In addition, I setup `domain: false` it's oriented for getting a generic url domain avatar and in this case you are using it for getting specific channel avatar based on url.

I feel I can refactor `domain` into a more generic field called `url` for adding this behavior.