### PR TITLE
Add DeviantArt username support

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -85,6 +85,9 @@
     <h3>Clearbit</h3>
     <p><code>&lt;img src="https://unavatar.now.sh/domain/:domain" /&gt;</code></p>
     <p>i.e <a target="_blank" href="https://unavatar.now.sh/clearbit/reddit.com">https://unavatar.now.sh/clearbit/reddit.com</a></p>
+    <h3>DeviantArt</h3>
+    <p><code>&lt;img src="https://unavatar.now.sh/deviantart/:username" /&gt;</code></p>
+    <p>i.e <a target="_blank" href="https://unavatar.now.sh/deviantart/spyed">https://unavatar.now.sh/deviantart/spyed</a></p>
   </article>
   <script src="js/main.min.js"></script>
 </body>

--- a/src/index.js
+++ b/src/index.js
@@ -41,7 +41,7 @@ router.get('/favicon.txt', (req, res) => res.status(204).send())
 
 const getAvatar = createGetAvatarUrl()
 
-router.get(`/:key`, (req, res) => ssrCache({ req, res, fn: getAvatar }))
+router.get('/:key', (req, res) => ssrCache({ req, res, fn: getAvatar }))
 
 forEach(providers, (fn, provider) => {
   const getAvatarByProvider = createGetAvatarUrl(fn)

--- a/src/providers/deviantart.js
+++ b/src/providers/deviantart.js
@@ -3,7 +3,7 @@
 const cheerio = require('cheerio')
 const got = require('got')
 
-const REGEX_PROFILE_URL = /^https?:\/\/(?:www\.)?deviantart\.com\/([\w\-]+)(?:\/.+)?$/
+const REGEX_PROFILE_URL = /^https?:\/\/(?:www\.)?deviantart\.com\/([\w-]+)(?:\/.+)?$/
 
 module.exports = async username => {
   const { body } = await got(`https://www.deviantart.com/${username}`)

--- a/src/providers/deviantart.js
+++ b/src/providers/deviantart.js
@@ -1,6 +1,27 @@
 'use strict'
 
+const { filter } = require('lodash')
+const { JSDOM } = require('jsdom')
 const got = require('got')
+
+const REGEX_PROFILE_URL = /^https?:\/\/(?:www\.)?deviantart\.com\/([\w\-]+)$/
+
+module.exports = async username => {
+  const { body } = await got(`https://www.deviantart.com/${username}`)
+  const { window } = new JSDOM(body, { runScripts: 'dangerously' })
+  const canonUsername = window.document
+    .querySelector('head link[rel=canonical]')
+    .getAttribute('href')
+    .replace(REGEX_PROFILE_URL, '$1')
+  const els = filter(
+    window.document.querySelectorAll('img.avatar,a[data-hook=user_link][data-icon]'),
+    el => {
+      const thisUsername = el.getAttribute('data-username') || el.getAttribute('title')
+      return canonUsername.toLowerCase() === thisUsername.toLowerCase()
+    }
+  )
+  return els[0].getAttribute('data-icon') || els[0].getAttribute('src')
+}
 
 module.exports.supported = {
   email: false,

--- a/src/providers/deviantart.js
+++ b/src/providers/deviantart.js
@@ -3,7 +3,7 @@
 const cheerio = require('cheerio')
 const got = require('got')
 
-const REGEX_PROFILE_URL = /^https?:\/\/(?:www\.)?deviantart\.com\/([\w\-]+)$/
+const REGEX_PROFILE_URL = /^https?:\/\/(?:www\.)?deviantart\.com\/([\w\-]+)(?:\/.+)?$/
 
 module.exports = async username => {
   const { body } = await got(`https://www.deviantart.com/${username}`)
@@ -12,7 +12,7 @@ module.exports = async username => {
     .attr('href')
     .replace(REGEX_PROFILE_URL, '$1')
   const els = $('img.avatar,a[data-hook=user_link][data-icon]').filter((i, el) => {
-    const thisUsername = $(el).attr('data-username') || $(el).attr('title')
+    const thisUsername = $(el).attr('data-username') || $(el).attr('title') || ''
     return canonUsername.toLowerCase() === thisUsername.toLowerCase()
   })
   return els.attr('data-icon') || els.attr('src')

--- a/src/providers/deviantart.js
+++ b/src/providers/deviantart.js
@@ -1,26 +1,21 @@
 'use strict'
 
-const { filter } = require('lodash')
-const { JSDOM } = require('jsdom')
+const cheerio = require('cheerio')
 const got = require('got')
 
 const REGEX_PROFILE_URL = /^https?:\/\/(?:www\.)?deviantart\.com\/([\w\-]+)$/
 
 module.exports = async username => {
   const { body } = await got(`https://www.deviantart.com/${username}`)
-  const { window } = new JSDOM(body, { runScripts: 'dangerously' })
-  const canonUsername = window.document
-    .querySelector('head link[rel=canonical]')
-    .getAttribute('href')
+  const $ = cheerio.load(body)
+  const canonUsername = $('head link[rel=canonical]')
+    .attr('href')
     .replace(REGEX_PROFILE_URL, '$1')
-  const els = filter(
-    window.document.querySelectorAll('img.avatar,a[data-hook=user_link][data-icon]'),
-    el => {
-      const thisUsername = el.getAttribute('data-username') || el.getAttribute('title')
-      return canonUsername.toLowerCase() === thisUsername.toLowerCase()
-    }
-  )
-  return els[0].getAttribute('data-icon') || els[0].getAttribute('src')
+  const els = $('img.avatar,a[data-hook=user_link][data-icon]').filter((i, el) => {
+    const thisUsername = $(el).attr('data-username') || $(el).attr('title')
+    return canonUsername.toLowerCase() === thisUsername.toLowerCase()
+  })
+  return els.attr('data-icon') || els.attr('src')
 }
 
 module.exports.supported = {

--- a/src/providers/deviantart.js
+++ b/src/providers/deviantart.js
@@ -1,0 +1,9 @@
+'use strict'
+
+const got = require('got')
+
+module.exports.supported = {
+  email: false,
+  username: true,
+  domain: false
+}

--- a/src/providers/index.js
+++ b/src/providers/index.js
@@ -9,6 +9,7 @@ const providers = {
   github: require('./github'),
   facebook: require('./facebook'),
   youtube: require('./youtube'),
+  deviantart: require('./deviantart'),
   // gravatar returns a default avatar, so use it as fallback
   gravatar: require('./gravatar')
 }


### PR DESCRIPTION
### description
This provider scraped the DeviantArt profile page for user avatars

### remarks
- since a deviant user can change their username, a regex is used to detect their current one
- since deviantart website is currently in transition to a new version called eclipse, both types of element selectors are used

### tests
- ✔️ `http://unavatar.now.local:3000/da-droid` (tests username redirection)
- ✔️ `http://unavatar.now.local:3000/deviantart/dadroid-bot` (explicit username)

<sup>n.b. `unavatar.now.local` is a hosts entry that points to `127.0.0.1` :)</sup>

### status
PR is ready to be merged!