### PR TITLE
Add Telegram username support

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -79,6 +79,9 @@
     <h3>Twitter</h3>
     <p><code>&lt;img src="https://unavatar.now.sh/twitter/:username" /&gt;</code></p>
     <p>i.e <a target="_blank" href="https://unavatar.now.sh/twitter/kikobeats">https://unavatar.now.sh/twitter/kikobeats</a></p>
+    <h3>Telegram</h3>
+    <p><code>&lt;img src="https://unavatar.now.sh/telegram/:username" /&gt;</code></p>
+    <p>i.e <a target="_blank" href="https://unavatar.now.sh/telegram/drsdavidsoft">https://unavatar.now.sh/telegram/drsdavidsoft</a></p>
     <h3>YouTube</h3>
     <p><code>&lt;img src="https://unavatar.now.sh/youtube/:username" /&gt;</code></p>
     <p>i.e <a target="_blank" href="https://unavatar.now.sh/youtube/caseyneistat">https://unavatar.now.sh/youtube/caseyneistat</a></p>

--- a/src/providers/index.js
+++ b/src/providers/index.js
@@ -8,6 +8,7 @@ const providers = {
   clearbit: require('./clearbit'),
   github: require('./github'),
   facebook: require('./facebook'),
+  telegram: require('./telegram'),
   youtube: require('./youtube'),
   deviantart: require('./deviantart'),
   // gravatar returns a default avatar, so use it as fallback

--- a/src/providers/telegram.js
+++ b/src/providers/telegram.js
@@ -1,0 +1,17 @@
+'use strict'
+
+const cheerio = require('cheerio')
+const got = require('got')
+
+module.exports = async username => {
+  const { body } = await got(`https://t.me/${username}`)
+  const $ = cheerio.load(body)
+  const el = $('img.tgme_page_photo_image')
+  return el.attr('src')
+}
+
+module.exports.supported = {
+  email: false,
+  username: true,
+  domain: false
+}


### PR DESCRIPTION
### description
This provider scrapes the Telegram profile page for user avatars

### remarks
- `t.me/:username` is a short domain that Telegram officially use to redirect to their app
- the actual profile image is usually hosted at `telesco.pe` domain (i believe it's their cdn)

### tests
- ✔️ `http://unavatar.now.local:3000/drsdavidsoft` (seems to work)
- ✔️ `http://unavatar.now.local:3000/deviantart/drsdavidsoft` (explicit username)

<sup>n.b. 1. `unavatar.now.local` is a hosts entry that points to `127.0.0.1`</sup>
<sup>n.b. 2. this time I made sure to follow the commit convention and run lint tests :)</sup>

### status
PR is ready to be merged!