### PR TITLE
Improve Gravatar hash creation

### DIFF
--- a/src/providers/gravatar.js
+++ b/src/providers/gravatar.js
@@ -13,7 +13,7 @@ const md5 = str =>
     .digest('hex')
 
 module.exports = async username => {
-  const avatarUrl = `https://gravatar.com/avatar/${md5(username)}?${stringify({
+  const avatarUrl = `https://gravatar.com/avatar/${md5(username.trim().toLowerCase())}?${stringify({
     size: AVATAR_SIZE,
     d: '404'
   })}`


### PR DESCRIPTION
Gravatar documentation states that the provided email string should be stripped from leading and trailing whitespaces. It should also be lowercased before computing the md5 hash. https://en.gravatar.com/site/implement/hash/