### PR TITLE
Add domain fallback/favicon DuckDuckGo provider

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -82,6 +82,9 @@
     <h3>Dribbble</h3>
     <p><code>&lt;img src="https://unavatar.now.sh/dribbble/:username" /&gt;</code></p>
     <p>e.g., <a target="_blank" href="https://unavatar.now.sh/dribbble/omidnikrah">https://unavatar.now.sh/dribbble/omidnikrah</a></p>
+    <h3>DuckDuckGo</h3>
+    <p><code>&lt;img src="https://unavatar.now.sh/duckduckgo/:domain" /&gt;</code></p>
+    <p>e.g., <a target="_blank" href="https://unavatar.now.sh/duckduckgo/gummibeer.dev">https://unavatar.now.sh/duckduckgo/gummibeer.dev</a></p>
     <h3>Facebook</h3>
     <p><code>&lt;img src="https://unavatar.now.sh/facebook/:username" /&gt;</code></p>
     <p>e.g., <a target="_blank" href="https://unavatar.now.sh/facebook/zuck">https://unavatar.now.sh/facebook/zuck</a></p>

--- a/src/providers/duckduckgo.js
+++ b/src/providers/duckduckgo.js
@@ -1,0 +1,16 @@
+'use strict'
+
+const got = require('got')
+
+module.exports = async url => {
+  const logoUrl = `https://icons.duckduckgo.com/ip3/${url}.ico`
+
+  await got.head(logoUrl)
+  return logoUrl
+}
+
+module.exports.supported = {
+  email: false,
+  username: false,
+  domain: true
+}

--- a/src/providers/index.js
+++ b/src/providers/index.js
@@ -15,7 +15,8 @@ const providers = {
   twitter: require('./twitter'),
   youtube: require('./youtube'),
   reddit: require('./reddit'),
-  dribbble: require('./dribbble')
+  dribbble: require('./dribbble'),
+  duckduckgo: require('./duckduckgo')
 }
 
 const providersBy = reduce(


### PR DESCRIPTION
This adds a new provider for domains - powered by DuckDuckGo - it will return the favicon.
The used `https://icons.duckduckgo.com/ip3/${url}.ico` endpoint is a more or less official one already used by KeePassXC, OhDear App and several more.
