### PR TITLE
Emergency Twitter fix

### DIFF
--- a/src/providers/twitter.js
+++ b/src/providers/twitter.js
@@ -1,20 +1,41 @@
 'use strict'
 
-const cheerio = require('cheerio')
 const got = require('got')
 
 // https://dev.twitter.com/basics/user-profile-images-and-banners
 const REGEX_IMG_MODIFIERS = /_(?:bigger|mini|normal)\./
 const ORIGINAL_IMG_SIZE = '_400x400'
 
-const getAvatarUrl = url =>
-  url.replace(REGEX_IMG_MODIFIERS, `${ORIGINAL_IMG_SIZE}.`)
+const getAvatarUrl = url => url.replace(REGEX_IMG_MODIFIERS, `${ORIGINAL_IMG_SIZE}.`)
 
 module.exports = async username => {
-  const { body } = await got(`https://mobile.twitter.com/${username}`)
-  const $ = cheerio.load(body)
-  const el = $('.avatar img').attr('src')
-  return getAvatarUrl(el)
+  // Get a fresh guest token
+  const { body: guestBody } = await got('https://twitter.com', {
+    headers: {
+      'User-Agent':
+        'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/87.0.4280.88 Safari/537.36'
+    }
+  })
+  const guestToken = guestBody.match(/gt=[0-9]*/gi)[0].slice(3)
+
+  // Request api endpoint with guest token. Bearer auth is hardcoded to this value.
+  const payload = { screen_name: username, withHighlightedLabel: true }
+  const { body: apiBody } = await got(
+    `https://twitter.com/i/api/graphql/ZRnOhhXPwue_JGILb9TNug/UserByScreenName?variables=${encodeURIComponent(
+      JSON.stringify(payload)
+    )}`,
+    {
+      headers: {
+        authorization:
+          'Bearer AAAAAAAAAAAAAAAAAAAAANRILgAAAAAAnNwIzUejRCOuH5E6I8xnZz4puTs%3D1Zv7ttfk8LF81IUq16cHjhLTvJu4FA33AGWWjCpTnA',
+        'x-guest-token': guestToken
+      }
+    }
+  )
+  const imgURL = JSON.parse(apiBody).data.user.legacy.profile_image_url_https
+
+  // Use _400x400 image size
+  return getAvatarUrl(imgURL)
 }
 
 module.exports.supported = {

--- a/src/providers/twitter.js
+++ b/src/providers/twitter.js
@@ -5,24 +5,28 @@ const got = require('got')
 // https://dev.twitter.com/basics/user-profile-images-and-banners
 const REGEX_IMG_MODIFIERS = /_(?:bigger|mini|normal)\./
 const ORIGINAL_IMG_SIZE = '_400x400'
+const TWITTER_BEARER_TOKEN =
+  'Bearer AAAAAAAAAAAAAAAAAAAAANRILgAAAAAAnNwIzUejRCOuH5E6I8xnZz4puTs%3D1Zv7ttfk8LF81IUq16cHjhLTvJu4FA33AGWWjCpTnA'
 
 const getAvatarUrl = url => url.replace(REGEX_IMG_MODIFIERS, `${ORIGINAL_IMG_SIZE}.`)
 
 module.exports = async username => {
   // Get a fresh guest token
-  console.log('Requesting Twitter user', username)
-  const { body: guestBody } = await got(
-    `https://twitter.com/?prefetchTimestamp=${Date.now().toString()}`,
-    {
-      headers: {
-        'User-Agent':
-          'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/87.0.4280.88 Safari/537.36'
-      }
+  const { body: guestBody } = await got.post('https://api.twitter.com/1.1/guest/activate.json', {
+    https: {
+      rejectUnauthorized: false
+    },
+    responseType: 'json',
+    headers: {
+      authorization: TWITTER_BEARER_TOKEN,
+      origin: 'https://twitter.com',
+      'user-agent':
+        'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/87.0.4280.88 Safari/537.36'
     }
-  )
-  console.log('Got twitter.com response', guestBody)
-  const guestToken = guestBody.match(/gt=[0-9]*/gi)[0].slice(3)
-  console.log('Extracted guest token', guestToken)
+  })
+
+  const guestToken = guestBody.guest_token
+  console.log(guestToken)
 
   // Request api endpoint with guest token. Bearer auth is hardcoded to this value.
   const payload = { screen_name: username, withHighlightedLabel: true }
@@ -33,13 +37,12 @@ module.exports = async username => {
     )}`,
     {
       headers: {
-        authorization:
-          'Bearer AAAAAAAAAAAAAAAAAAAAANRILgAAAAAAnNwIzUejRCOuH5E6I8xnZz4puTs%3D1Zv7ttfk8LF81IUq16cHjhLTvJu4FA33AGWWjCpTnA',
+        authorization: TWITTER_BEARER_TOKEN,
         'x-guest-token': guestToken
       }
     }
   )
-  console.log('Got api response', apiBody)
+  // console.log('Got api response', apiBody)
   const imgURL = JSON.parse(apiBody).data.user.legacy.profile_image_url_https
   console.log('Extracted img url', imgURL)
 

--- a/src/providers/twitter.js
+++ b/src/providers/twitter.js
@@ -24,13 +24,10 @@ module.exports = async username => {
         'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/87.0.4280.88 Safari/537.36'
     }
   })
-
   const guestToken = guestBody.guest_token
-  console.log(guestToken)
 
   // Request api endpoint with guest token. Bearer auth is hardcoded to this value.
   const payload = { screen_name: username, withHighlightedLabel: true }
-  console.log('Api request payload', payload)
   const { body: apiBody } = await got(
     `https://twitter.com/i/api/graphql/ZRnOhhXPwue_JGILb9TNug/UserByScreenName?variables=${encodeURIComponent(
       JSON.stringify(payload)
@@ -42,9 +39,7 @@ module.exports = async username => {
       }
     }
   )
-  // console.log('Got api response', apiBody)
   const imgURL = JSON.parse(apiBody).data.user.legacy.profile_image_url_https
-  console.log('Extracted img url', imgURL)
 
   // Use _400x400 image size
   return getAvatarUrl(imgURL)

--- a/src/providers/twitter.js
+++ b/src/providers/twitter.js
@@ -10,16 +10,20 @@ const getAvatarUrl = url => url.replace(REGEX_IMG_MODIFIERS, `${ORIGINAL_IMG_SIZ
 
 module.exports = async username => {
   // Get a fresh guest token
+  console.log('Requesting Twitter user', username)
   const { body: guestBody } = await got('https://twitter.com', {
     headers: {
       'User-Agent':
         'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/87.0.4280.88 Safari/537.36'
     }
   })
+  console.log('Got twitter.com response', guestBody)
   const guestToken = guestBody.match(/gt=[0-9]*/gi)[0].slice(3)
+  console.log('Extracted guest token', guestToken)
 
   // Request api endpoint with guest token. Bearer auth is hardcoded to this value.
   const payload = { screen_name: username, withHighlightedLabel: true }
+  console.log('Api request payload', payload)
   const { body: apiBody } = await got(
     `https://twitter.com/i/api/graphql/ZRnOhhXPwue_JGILb9TNug/UserByScreenName?variables=${encodeURIComponent(
       JSON.stringify(payload)
@@ -32,7 +36,9 @@ module.exports = async username => {
       }
     }
   )
+  console.log('Got api response', apiBody)
   const imgURL = JSON.parse(apiBody).data.user.legacy.profile_image_url_https
+  console.log('Extracted img url', imgURL)
 
   // Use _400x400 image size
   return getAvatarUrl(imgURL)

--- a/src/providers/twitter.js
+++ b/src/providers/twitter.js
@@ -11,12 +11,15 @@ const getAvatarUrl = url => url.replace(REGEX_IMG_MODIFIERS, `${ORIGINAL_IMG_SIZ
 module.exports = async username => {
   // Get a fresh guest token
   console.log('Requesting Twitter user', username)
-  const { body: guestBody } = await got('https://twitter.com', {
-    headers: {
-      'User-Agent':
-        'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/87.0.4280.88 Safari/537.36'
+  const { body: guestBody } = await got(
+    `https://twitter.com/?prefetchTimestamp=${Date.now().toString()}`,
+    {
+      headers: {
+        'User-Agent':
+          'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/87.0.4280.88 Safari/537.36'
+      }
     }
-  })
+  )
   console.log('Got twitter.com response', guestBody)
   const guestToken = guestBody.match(/gt=[0-9]*/gi)[0].slice(3)
   console.log('Extracted guest token', guestToken)


### PR DESCRIPTION
Today Twitter has removed legacy device support for devices which do not support Javascript. Now all images etc. are dynamically loaded with XHR requests when the site loads. This breaks the current Twitter implementation.

Below is an emergency fix which works for now even though there might be a better way to do it in the future. 

Fixes #121 