### PR TITLE
Improve Substack implementation

### DIFF
--- a/src/providers/substack.js
+++ b/src/providers/substack.js
@@ -6,7 +6,7 @@ const got = require('got')
 module.exports = async username => {
   const { body } = await got(`https://${username}.substack.com`)
   const $ = cheerio.load(body)
-  return $('img.publication-logo').attr('src')
+  return $('link[rel=apple-touch-icon][sizes=120x120]').attr('href')
 }
 
 module.exports.supported = {


### PR DESCRIPTION
The current Substack implementation has a problem where for some publications the avatar could not be found in the response.

Example:
- Works: [Unavatar Bankless](https://unavatar.now.sh/substack/bankless) (https://bankless.substack.com/)
- Fails: [Unavatar Astralcodexten](https://unavatar.now.sh/substack/astralcodexten) (https://astralcodexten.substack.com/)

Fixed by reading the avatar from another location in the HTML which is always present.